### PR TITLE
[host-local plugin] support read from file

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -137,7 +137,6 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 			return nil, "", fmt.Errorf("failed to read rangeFromFile %q: %v", n.IPAM.RangeFromFile, err)
 		}
 
-		// Try to unmarshal as a single Range first, then as a slice
 		var singleRange Range
 		if err := json.Unmarshal(fileBytes, &singleRange); err == nil {
 			if singleRange.Subnet.IP != nil {


### PR DESCRIPTION
This PR adds one more field in host-local ipam plugin's config so it reads ranges from a host local file. Benefits are:
1. we avoid having one NetworkAttachmentDefinition per host.
2. capi's logic to add multus annotations onto RoCE pods is also simplified because it can hardcode the list of NADs

The file on host will contain the subnet, rangeStart and rangeEnd based on the ipv4 IP on eth0, and is populated by a separate systemd unit.


To build it:
```
GOOS=linux GOARCH=amd64 go build -o host-local ./main.go
```
To cp it into node:
```
ak c189 cp ./host-local-macvlan fy-nsenter-inst-7gvm7-gpu-cluster-network:/opt/cni/bin/host-local-macvlan
```

There is no CI setup for this forked repo, but to run the newly added unit test
```
 go test .
ok  	github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator	1.092s
```


Next:
1. figure out a way to build an oai image from this binary.